### PR TITLE
Fix bitbucker repo url

### DIFF
--- a/lib/generator/bitbucket.js
+++ b/lib/generator/bitbucket.js
@@ -28,8 +28,8 @@ Bitbucket.prototype.generate = function (cb) {
     if (!err) {
       repos.forEach(function (repo) {
         if (repo.scm === 'git') {
-          url = util.format('ssh://git@bitbucket.org/%s/%s.git', self.user, repo.name); 
-          config[repo.name] = { url: url };
+          url = util.format('ssh://git@bitbucket.org/%s/%s.git', repo.owner, repo.slug);
+          config[repo.slug] = { url: url };
         } else {
           console.error('TODO: %s scm is not yet supported', repo.scm);
         }


### PR DESCRIPTION
I ran into some issues while running repoman config with bitbucket.
The git urls in the generated config were wrong in some cases.

Bitbucket repositories can have slashes in their "friendly" name. Repoman generated the git url with the friendly name, causing repoman init to fail. I replaced the name with the identifier (slug). See https://confluence.atlassian.com/display/BITBUCKET/repositories+Endpoint+-+1.0

A user can also have repositories owned by others (like teams, etc.). The git urls for those repos were also wrong, cause repoman assumed that the authenticated user is the owner.